### PR TITLE
feat: migrate repo path from ~/dev/dotfiles to ~/.dotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ macOS dotfiles managed with Nix flakes, nix-darwin, and home-manager.
 3. Clone this repository:
 
    ```bash
-   git clone https://github.com/mfyuu/dotfiles.git ~/dev/dotfiles
+   git clone https://github.com/mfyuu/dotfiles.git ~/.dotfiles
    ```
 
 4. Apply the nix-darwin configuration [^2] [^3]:
 
    ```bash
    # Replace <hostname> with your machine name (M4Pro, M4Air, etc.)
-   sudo nix run nix-darwin -- switch --flake ~/dev/dotfiles#<hostname>
+   sudo nix run nix-darwin -- switch --flake ~/.dotfiles#<hostname>
    ```
 
 5. Reload your shell:
@@ -44,7 +44,7 @@ macOS dotfiles managed with Nix flakes, nix-darwin, and home-manager.
 
 ## Daily Usage
 
-Run these commands from the dotfiles directory (`~/dev/dotfiles`):
+Run these commands from the dotfiles directory (`~/.dotfiles`):
 
 ```bash
 # Update flake.lock (fetch latest nixpkgs, nix-darwin, home-manager)
@@ -58,7 +58,7 @@ nix run .#build
 ```
 
 > [!NOTE]
-> If running from outside the dotfiles directory, replace `.` with the path to the repository (e.g., `nix run ~/dev/dotfiles#update`).
+> If running from outside the dotfiles directory, replace `.` with the path to the repository (e.g., `nix run ~/.dotfiles#update`).
 
 ## Benchmark
 

--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,7 @@
             pkgs.writeShellScript "flake-update" ''
               set -e
               echo "Updating flake.lock..."
-              nix flake update --flake "$HOME/dev/dotfiles"
+              nix flake update --flake "$HOME/.dotfiles"
               echo "Done! Run 'nix run .#switch' to apply changes."
             ''
           );
@@ -61,7 +61,7 @@
               echo "Updating Homebrew..."
               /opt/homebrew/bin/brew update
               echo "Building and switching to darwin configuration for $HOST_NAME..."
-              sudo nix run nix-darwin -- switch --flake "$HOME/dev/dotfiles#$HOST_NAME" |& ${pkgs.nix-output-monitor}/bin/nom
+              sudo nix run nix-darwin -- switch --flake "$HOME/.dotfiles#$HOST_NAME" |& ${pkgs.nix-output-monitor}/bin/nom
               echo "Done!"
             ''
           );
@@ -73,7 +73,7 @@
               set -e
               HOST_NAME=$(scutil --get LocalHostName)
               echo "Building darwin configuration for $HOST_NAME..."
-              ${pkgs.nix-output-monitor}/bin/nom build "$HOME/dev/dotfiles#darwinConfigurations.$HOST_NAME.system"
+              ${pkgs.nix-output-monitor}/bin/nom build "$HOME/.dotfiles#darwinConfigurations.$HOST_NAME.system"
               echo "Build successful! Run 'nix run .#switch' to apply."
             ''
           );


### PR DESCRIPTION
<!-- Instructions for GitHub Copilot Code Review: Please provide your comments and review this pull request in Japanese. -->

## Issue

fixes #8

## Changes

- `flake.nix`: update, switch, build の3つのアプリで `$HOME/dev/dotfiles` → `$HOME/.dotfiles` に変更
- `README.md`: セットアップ手順・日常使用の説明で `~/dev/dotfiles` → `~/.dotfiles` に変更（4箇所）

## Verification

- [x] No lint/type errors
- [x] No breaking changes introduced
- [x] Changeset file created (if needed for version bump)

## Additional Notes

`~/dev/` を `work/private/oss` でカテゴリ分けしていく予定のため、カテゴリに属さない dotfiles リポジトリを `~/.dotfiles` に移行する。